### PR TITLE
feat: add Wezterm support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 The following terminal emulators are supported
 - [iTerm2](https://iterm2.com/documentation-shell-integration.html)
 - [kitty](https://sw.kovidgoyal.net/kitty/shell-integration/)
+- [WezTerm](https://wezfurlong.org/wezterm/shell-integration.html) with CWD; Input, Output, and Prompt zones; and User Vars for tracking additional shell state
 
 **Note**: If identifying current terminal fails, `iTerm2` hooks are loaded.
 

--- a/xontrib/term_integration.py
+++ b/xontrib/term_integration.py
@@ -9,9 +9,15 @@ env = XSH.env or {}
 
 # load during interactive sessions only
 if env.get("XONSH_INTERACTIVE", False):
-    if ("kitty" in os.getenv("TERMINFO", "")) or ("kitty" in os.getenv("TERM", "")):
-        import xontrib_term_integrations.kitty  # noqa
-    else:
-        # fallback
-        # if "iTerm" in os.getenv("TERM_PROGRAM", ""):
-        import xontrib_term_integrations.iterm2  # noqa
+    TERMINFO     = os.getenv("TERMINFO"    , "").lower()
+    TERM         = os.getenv("TERM"        , "").lower()
+    # avoid terminals that don't like OSC sequences
+    if  not TERM == "dumb" and\
+        not TERM == "linux":
+            if   ("kitty"   in TERMINFO    ) or\
+                 ("kitty"   in TERM        ):
+                import xontrib_term_integrations.kitty  # noqa
+            else:
+                # fallback
+                # if "iTerm" in os.getenv("TERM_PROGRAM", ""):
+                import xontrib_term_integrations.iterm2  # noqa

--- a/xontrib/term_integration.py
+++ b/xontrib/term_integration.py
@@ -22,6 +22,7 @@ if env.get("XONSH_INTERACTIVE", False):
                  ("wezterm" in TERM        ) or\
                  ("wezterm" in TERM_PROGRAM):
                 import xontrib_term_integrations.wezterm # noqa
+                #todo: fails in a root shell https://github.com/wez/wezterm/issues/3114
             else:
                 # fallback
                 # if "iTerm" in os.getenv("TERM_PROGRAM", ""):

--- a/xontrib/term_integration.py
+++ b/xontrib/term_integration.py
@@ -11,12 +11,17 @@ env = XSH.env or {}
 if env.get("XONSH_INTERACTIVE", False):
     TERMINFO     = os.getenv("TERMINFO"    , "").lower()
     TERM         = os.getenv("TERM"        , "").lower()
+    TERM_PROGRAM = os.getenv("TERM_PROGRAM", "").lower()
     # avoid terminals that don't like OSC sequences
     if  not TERM == "dumb" and\
         not TERM == "linux":
             if   ("kitty"   in TERMINFO    ) or\
                  ("kitty"   in TERM        ):
                 import xontrib_term_integrations.kitty  # noqa
+            elif ("wezterm" in TERMINFO    ) or\
+                 ("wezterm" in TERM        ) or\
+                 ("wezterm" in TERM_PROGRAM):
+                import xontrib_term_integrations.wezterm # noqa
             else:
                 # fallback
                 # if "iTerm" in os.getenv("TERM_PROGRAM", ""):

--- a/xontrib/term_integration.py
+++ b/xontrib/term_integration.py
@@ -9,21 +9,22 @@ env = XSH.env or {}
 
 # load during interactive sessions only
 if env.get("XONSH_INTERACTIVE", False):
-    TERMINFO     = os.getenv("TERMINFO"    , "").lower()
-    TERM         = os.getenv("TERM"        , "").lower()
+    TERMINFO = os.getenv("TERMINFO", "").lower()
+    TERM = os.getenv("TERM", "").lower()
     TERM_PROGRAM = os.getenv("TERM_PROGRAM", "").lower()
     # avoid terminals that don't like OSC sequences
-    if  not TERM == "dumb" and\
-        not TERM == "linux":
-            if   ("kitty"   in TERMINFO    ) or\
-                 ("kitty"   in TERM        ):
-                import xontrib_term_integrations.kitty  # noqa
-            elif ("wezterm" in TERMINFO    ) or\
-                 ("wezterm" in TERM        ) or\
-                 ("wezterm" in TERM_PROGRAM):
-                import xontrib_term_integrations.wezterm # noqa
-                #todo: fails in a root shell https://github.com/wez/wezterm/issues/3114
-            else:
-                # fallback
-                # if "iTerm" in os.getenv("TERM_PROGRAM", ""):
-                import xontrib_term_integrations.iterm2  # noqa
+    if not TERM == "dumb" and not TERM == "linux":
+        if ("kitty" in TERMINFO) or ("kitty" in TERM):
+            import xontrib_term_integrations.kitty  # noqa
+        elif (
+            ("wezterm" in TERMINFO)
+            or ("wezterm" in TERM)
+            or ("wezterm" in TERM_PROGRAM)
+        ):
+            import xontrib_term_integrations.wezterm  # noqa
+
+            # todo: fails in a root shell https://github.com/wez/wezterm/issues/3114
+        else:
+            # fallback
+            # if "iTerm" in os.getenv("TERM_PROGRAM", ""):
+            import xontrib_term_integrations.iterm2  # noqa

--- a/xontrib_term_integrations/utils.py
+++ b/xontrib_term_integrations/utils.py
@@ -41,6 +41,10 @@ def term_osc_cmd(code):
     return f"{Codes.OSC}1337;{code}{Codes.BEL}"
 
 
+def term_osc7_cmd(code):
+    return f"{Codes.OSC}7;{code}{Codes.ST}"
+
+
 def term_dcs_cmd(code):
     return f"{Codes.DCS}{code}{Codes.ST}"
 
@@ -69,6 +73,10 @@ def write_term_mark(code):
 
 def write_osc_cmd(code):
     return write_to_out(term_osc_cmd(code))
+
+
+def write_osc7_cmd(code):
+    return write_to_out(term_osc7_cmd(code))
 
 
 def write_dcs_cmd(code):
@@ -101,6 +109,11 @@ def write_osc_cwd(newdir):
     # OSC 1337 ; CurrentDir=[current directory] ST
     write_osc_cmd(f"CurrentDir={newdir}")
 
+
+def write_osc7_cwd(host, newdir):
+    # OSC 7 ; [Ps] ST
+    #         [Ps] is a file URL with a hostname and a path, like file://example.com/usr/bin
+    write_osc7_cmd(f"file://{host}{newdir}")
 
 def write_osc_user_host(env):
     user = env.get("USER")

--- a/xontrib_term_integrations/utils.py
+++ b/xontrib_term_integrations/utils.py
@@ -10,6 +10,7 @@ class Codes:
     ST  = ESC + "\\" # 0x9C String Terminator: terminates strings in other controls
     OSC = ESC + "]"  # \x5d Operating System Command
     CSI = ESC + "["  #      Control Sequence Introducer
+    DCS = ESC + "P"  # 0x90 Device Control String (terminated by ST): User-Defined Keys; get/set Termcap/Terminfo data
 
 class ShellIntegrationPrompt:
     def __init__(self, env: "Env"):
@@ -37,6 +38,20 @@ def term_osc_cmd(code):
     return f"{Codes.OSC}1337;{code}{Codes.BEL}"
 
 
+def term_dcs_cmd(code):
+    return f"{Codes.DCS}{code}{Codes.ST}"
+
+
+def term_tmux_cmd(code):
+    # github.com/tmux/tmux/wiki/FAQ#what-is-the-passthrough-escape-sequence-and-how-do-i-use-it
+    # ESC in the wrapped sequence must be doubled
+    return term_dcs_cmd(esc_esc(code))
+
+
+def esc_esc(code): # doubles ESC (or escapes ESC with another ESC)
+    return code.replace(Codes.ESC, Codes.ESC+Codes.ESC)
+
+
 def form_term_prompt_prefix():
     return term_mark("A")
 
@@ -51,6 +66,14 @@ def write_term_mark(code):
 
 def write_osc_cmd(code):
     return write_to_out(term_osc_cmd(code))
+
+
+def write_dcs_cmd(code):
+    return write_to_out(term_dcs_cmd(code))
+
+
+def write_tmux_cmd(code):
+    return write_to_out(term_tmux_cmd(code))
 
 
 def write_osc_output_prefix():

--- a/xontrib_term_integrations/utils.py
+++ b/xontrib_term_integrations/utils.py
@@ -5,11 +5,11 @@ from xonsh.environ import Env
 
 class Codes:
     # https://iterm2.com/documentation-escape-codes.html equivalents
-    ESC = "\x1b"
-    ST = "\x07"
-    OSC = ESC + "]"  # \x5d
-    CSI = ESC + "["
-
+    ESC = "\x1b"     # Escape, starts all the escape sequences
+    BEL = "\x07"     # Bell
+    ST  = ESC + "\\" # 0x9C String Terminator: terminates strings in other controls
+    OSC = ESC + "]"  # \x5d Operating System Command
+    CSI = ESC + "["  #      Control Sequence Introducer
 
 class ShellIntegrationPrompt:
     def __init__(self, env: "Env"):
@@ -30,11 +30,11 @@ def ansi_esc(code: str):
 
 
 def term_mark(code):
-    return f"{Codes.OSC}133;{code}{Codes.ST}"
+    return f"{Codes.OSC}133;{code}{Codes.BEL}"
 
 
 def term_osc_cmd(code):
-    return f"{Codes.OSC}1337;{code}{Codes.ST}"
+    return f"{Codes.OSC}1337;{code}{Codes.BEL}"
 
 
 def form_term_prompt_prefix():

--- a/xontrib_term_integrations/utils.py
+++ b/xontrib_term_integrations/utils.py
@@ -60,10 +60,14 @@ def esc_esc(code): # doubles ESC (or escapes ESC with another ESC)
 
 
 def form_term_prompt_prefix():
+    # FTCS_PROMPT        Sent just before start of shell prompt
+    # OSC 133 ; A ST
     return term_mark("A")
 
 
 def form_term_prompt_suffix():
+    # FTCS_COMMAND_START Sent just after end of shell prompt, before the user-entered command
+    # OSC 133 ; B ST
     return term_mark("B")
 
 

--- a/xontrib_term_integrations/wezterm.py
+++ b/xontrib_term_integrations/wezterm.py
@@ -1,11 +1,11 @@
 # Hook up xonsh shell integration for WezTerm, but the sequences used are not WezTerm specific and may provide the same functionality for other terminals. Most terminals are good at ignoring OSC sequences that they don't understand, but if not there are some bypasses:
-    # WEZTERM_SHELL_SKIP_ALL            - disables all
-    # WEZTERM_SHELL_SKIP_SEMANTIC_ZONES - disables zones
-    # WEZTERM_SHELL_SKIP_CWD            - disables OSC 7 cwd setting
-    # WEZTERM_SHELL_SKIP_USER_VARS      - disable user vars that capture information about running programs
+# WEZTERM_SHELL_SKIP_ALL            - disables all
+# WEZTERM_SHELL_SKIP_SEMANTIC_ZONES - disables zones
+# WEZTERM_SHELL_SKIP_CWD            - disables OSC 7 cwd setting
+# WEZTERM_SHELL_SKIP_USER_VARS      - disable user vars that capture information about running programs
 # How to test
-   # Set multiclick to select zones in WezTerm, then multiclick to see which areas select
-   # Use MoveForwardZoneOfType/MoveBackwardZoneOfType key bindings
+# Set multiclick to select zones in WezTerm, then multiclick to see which areas select
+# Use MoveForwardZoneOfType/MoveBackwardZoneOfType key bindings
 
 import os
 import subprocess
@@ -17,101 +17,112 @@ from . import utils
 env = XSH.env or {}
 evalx = XSH.builtins.evalx
 
-_skip_all     = env.get('WEZTERM_SHELL_SKIP_ALL'           , False)
-_skip_cwd     = env.get('WEZTERM_SHELL_SKIP_CWD'           , False)
-_skip_zone    = env.get('WEZTERM_SHELL_SKIP_SEMANTIC_ZONES', False)
-_skip_usr_var = env.get('WEZTERM_SHELL_SKIP_USER_VARS'     , False)
+_skip_all = env.get("WEZTERM_SHELL_SKIP_ALL", False)
+_skip_cwd = env.get("WEZTERM_SHELL_SKIP_CWD", False)
+_skip_zone = env.get("WEZTERM_SHELL_SKIP_SEMANTIC_ZONES", False)
+_skip_usr_var = env.get("WEZTERM_SHELL_SKIP_USER_VARS", False)
 
-get_bin      = XSH.commands_cache.locate_binary
+get_bin = XSH.commands_cache.locate_binary
 get_bin_lazy = XSH.commands_cache.lazy_locate_binary
-def _command(               name, ignore_alias=False):
+
+
+def _command(name, ignore_alias=False):
     """Find           command        in cache (including aliases)"""
-    return get_bin_lazy(    name, ignore_alias)
-def isCmd(                  name, ignore_alias=False):
+    return get_bin_lazy(name, ignore_alias)
+
+
+def isCmd(name, ignore_alias=False):
     """Test whether a command exists in cache (including aliases)"""
     return True if _command(name, ignore_alias) else False
 
+
 if not _skip_all:
+
     def wezterm_write_osc7_cwd(newdir):
-        host = env.get("HOSTNAME", '')
+        host = env.get("HOSTNAME", "")
         utils.write_osc7_cwd(host, newdir)
         # ↓ don't see the point in a helper function
         # emits an OSC 7 sequence to inform the terminal of the current working directory.  It prefers to use a helper command provided by WezTerm if WezTerm is installed, but falls back to a simple command otherwise
-        #if isCmd('wezterm') and\
-        #(0 == evalx('wezterm set-working-directory 2>/dev/null').returncode):
+        # if isCmd('wezterm') and\
+        # (0 == evalx('wezterm set-working-directory 2>/dev/null').returncode):
         #    return
-        #else:
+        # else:
         #    host = env.get("HOSTNAME", '')
         #    utils.write_osc7_cwd(host, newdir)
 
     if not _skip_zone:
-        @XSH.builtins.events.on_precommand # Fires just before a command is executed
-        def wezterm_cmd_pre(cmd:str, **_):
+
+        @XSH.builtins.events.on_precommand  # Fires just before a command is executed
+        def wezterm_cmd_pre(cmd: str, **_):
             """Write before starting to print out the output from the command"""
             utils.SemanticPrompt.write_input_end_output_start()
             if not _skip_usr_var:
-                utils.set_user_var("WEZTERM_PROG", cmd) # tell WezTerm the full command that is being run
+                utils.set_user_var(
+                    "WEZTERM_PROG", cmd
+                )  # tell WezTerm the full command that is being run
 
     @XSH.builtins.events.on_postcommand
-    def wezterm_cmd_pos(rtn=0, **_): # Inform WezTerm of command success/failure here
-        opt = {f'{rtn}':None, 'aid':os.getpid()}
+    def wezterm_cmd_pos(rtn=0, **_):  # Inform WezTerm of command success/failure here
+        opt = {f"{rtn}": None, "aid": os.getpid()}
         utils.SemanticPrompt.write_cmd_end(opt)
 
     if not _skip_cwd:
+
         @XSH.builtins.events.on_chdir
         def onchdir(olddir, newdir, **_):
             wezterm_write_osc7_cwd(newdir)
 
     if not _skip_usr_var:
-        @XSH.builtins.events.on_pre_prompt # Fires just before showing the prompt
+
+        @XSH.builtins.events.on_pre_prompt  # Fires just before showing the prompt
         def wezterm_prompt_pre():
             """Write before starting to print out the output from the command"""
-            promptx = env.get('PROMPT_FIELDS', []) # get Xonsh available prompt fields
+            promptx = env.get("PROMPT_FIELDS", [])  # get Xonsh available prompt fields
 
             # 1 tell WezTerm that no command is being run
             utils.set_user_var("WEZTERM_PROG", "")
 
             # 2 tell WezTerm the username
-            if (user_xon := promptx['user'] if 'user' in promptx else None):
+            if user_xon := promptx["user"] if "user" in promptx else None:
                 user = user_xon
-            else: # fallback to capturing `id -un` ??? likely never needed
-                full_cmd  = ['id','-un']
-                proc  = subprocess.run(full_cmd,capture_output=True)
-                out   = proc.stdout.decode().rstrip('\n')
-                err   = proc.stderr.decode().rstrip('\n')
-                retn  = proc.returncode
-                user  = out
+            else:  # fallback to capturing `id -un` ??? likely never needed
+                full_cmd = ["id", "-un"]
+                proc = subprocess.run(full_cmd, capture_output=True)
+                out = proc.stdout.decode().rstrip("\n")
+                err = proc.stderr.decode().rstrip("\n")
+                retn = proc.returncode
+                user = out
             utils.set_user_var("WEZTERM_USER", user)
 
             # 3 tell WezTerm the hostname
-            if   (hostname_wez := env.get('WEZTERM_HOSTNAME')):
+            if hostname_wez := env.get("WEZTERM_HOSTNAME"):
                 hostname = hostname_wez
-            elif (hostname_xon := promptx['hostname'] if 'hostname' in promptx else None):
+            elif hostname_xon := promptx["hostname"] if "hostname" in promptx else None:
                 hostname = hostname_xon
-            else: # fallback to calling out hostname/ctl ??? likely never needed
-                if   isCmd('hostname'):
-                    full_cmd  = ['hostname']
-                elif isCmd('hostnamectl'):
-                    full_cmd  = ['hostnamectl','hostname']
-                proc  = subprocess.run(full_cmd,capture_output=True)
-                out   = proc.stdout.decode().rstrip('\n')
-                err   = proc.stderr.decode().rstrip('\n')
-                retn  = proc.returncode
+            else:  # fallback to calling out hostname/ctl ??? likely never needed
+                if isCmd("hostname"):
+                    full_cmd = ["hostname"]
+                elif isCmd("hostnamectl"):
+                    full_cmd = ["hostnamectl", "hostname"]
+                proc = subprocess.run(full_cmd, capture_output=True)
+                out = proc.stdout.decode().rstrip("\n")
+                err = proc.stderr.decode().rstrip("\n")
+                retn = proc.returncode
                 hostname = out
-                print('set manual lhostname')
+                print("set manual lhostname")
             utils.set_user_var("WEZTERM_HOST", hostname)
 
             # 4 tell WezTerm whether the pane is running inside tmux
-            if env.get("TMUX", ''):
+            if env.get("TMUX", ""):
                 utils.set_user_var("WEZTERM_IN_TMUX", "1")
             else:
                 utils.set_user_var("WEZTERM_IN_TMUX", "0")
 
-
-    prompt_name = ["PROMPT","RIGHT_PROMPT","BOTTOM_TOOLBAR","MULTILINE_PROMPT"]
+    prompt_name = ["PROMPT", "RIGHT_PROMPT", "BOTTOM_TOOLBAR", "MULTILINE_PROMPT"]
     extend = False if _skip_zone else True
-    opt = {'cl':'m', 'aid':os.getpid()}
+    opt = {"cl": "m", "aid": os.getpid()}
     for prompt in prompt_name:
-        if  XSH.env[prompt]:
-            XSH.env[prompt] = utils.ShellIntegrationPrompt(XSH.env,
-                                prompt_name=prompt, extend=True, ext_opt=opt)
+        if XSH.env[prompt]:
+            XSH.env[prompt] = utils.ShellIntegrationPrompt(
+                XSH.env, prompt_name=prompt, extend=True, ext_opt=opt
+            )

--- a/xontrib_term_integrations/wezterm.py
+++ b/xontrib_term_integrations/wezterm.py
@@ -1,12 +1,17 @@
-# Hook up xonsh shell integration for WezTerm, but the sequences used are not WezTerm specific and may provide the same functionality for other terminals. Most terminals are good at ignoring OSC sequences that they don't understand, but if not there are some bypasses:
+# Hook up xonsh shell integration for WezTerm, but the sequences used are not WezTerm
+# specific and may provide the same functionality for other terminals.
+# Most terminals are good at ignoring OSC sequences that they don't understand,
+# but if not there are some bypasses:
 # WEZTERM_SHELL_SKIP_ALL            - disables all
 # WEZTERM_SHELL_SKIP_SEMANTIC_ZONES - disables zones
 # WEZTERM_SHELL_SKIP_CWD            - disables OSC 7 cwd setting
-# WEZTERM_SHELL_SKIP_USER_VARS      - disable user vars that capture information about running programs
+# WEZTERM_SHELL_SKIP_USER_VARS      - disable user vars that capture info about running
+# programs
 # How to test
 # Set multiclick to select zones in WezTerm, then multiclick to see which areas select
 # Use MoveForwardZoneOfType/MoveBackwardZoneOfType key bindings
 
+import sys
 import os
 import subprocess
 
@@ -42,7 +47,10 @@ if not _skip_all:
         host = env.get("HOSTNAME", "")
         utils.write_osc7_cwd(host, newdir)
         # ↓ don't see the point in a helper function
-        # emits an OSC 7 sequence to inform the terminal of the current working directory.  It prefers to use a helper command provided by WezTerm if WezTerm is installed, but falls back to a simple command otherwise
+        # emits an OSC 7 sequence to inform the terminal
+        # of the current working directory
+        # It prefers to use a helper command provided by WezTerm if is installed,
+        # but falls back to a simple command otherwise
         # if isCmd('wezterm') and\
         # (0 == evalx('wezterm set-working-directory 2>/dev/null').returncode):
         #    return
@@ -62,7 +70,7 @@ if not _skip_all:
                 )  # tell WezTerm the full command that is being run
 
     @XSH.builtins.events.on_postcommand
-    def wezterm_cmd_pos(rtn=0, **_):  # Inform WezTerm of command success/failure here
+    def wezterm_cmd_pos(rtn=0, **_):  # Inform WezTerm of command success/failure
         opt = {f"{rtn}": None, "aid": os.getpid()}
         utils.SemanticPrompt.write_cmd_end(opt)
 
@@ -77,7 +85,8 @@ if not _skip_all:
         @XSH.builtins.events.on_pre_prompt  # Fires just before showing the prompt
         def wezterm_prompt_pre():
             """Write before starting to print out the output from the command"""
-            promptx = env.get("PROMPT_FIELDS", [])  # get Xonsh available prompt fields
+            # get Xonsh available prompt fields
+            promptx = env.get("PROMPT_FIELDS", [])
 
             # 1 tell WezTerm that no command is being run
             utils.set_user_var("WEZTERM_PROG", "")
@@ -89,8 +98,7 @@ if not _skip_all:
                 full_cmd = ["id", "-un"]
                 proc = subprocess.run(full_cmd, capture_output=True)
                 out = proc.stdout.decode().rstrip("\n")
-                err = proc.stderr.decode().rstrip("\n")
-                retn = proc.returncode
+                print(proc.stderr.decode().rstrip("\n"), file=sys.stderr)
                 user = out
             utils.set_user_var("WEZTERM_USER", user)
 
@@ -99,17 +107,15 @@ if not _skip_all:
                 hostname = hostname_wez
             elif hostname_xon := promptx["hostname"] if "hostname" in promptx else None:
                 hostname = hostname_xon
-            else:  # fallback to calling out hostname/ctl ??? likely never needed
+            else:  # fallback to calling out hostname/ctl
                 if isCmd("hostname"):
                     full_cmd = ["hostname"]
                 elif isCmd("hostnamectl"):
                     full_cmd = ["hostnamectl", "hostname"]
                 proc = subprocess.run(full_cmd, capture_output=True)
                 out = proc.stdout.decode().rstrip("\n")
-                err = proc.stderr.decode().rstrip("\n")
-                retn = proc.returncode
+                print(proc.stderr.decode().rstrip("\n"), file=sys.stderr)
                 hostname = out
-                print("set manual lhostname")
             utils.set_user_var("WEZTERM_HOST", hostname)
 
             # 4 tell WezTerm whether the pane is running inside tmux

--- a/xontrib_term_integrations/wezterm.py
+++ b/xontrib_term_integrations/wezterm.py
@@ -1,0 +1,117 @@
+# Hook up xonsh shell integration for WezTerm, but the sequences used are not WezTerm specific and may provide the same functionality for other terminals. Most terminals are good at ignoring OSC sequences that they don't understand, but if not there are some bypasses:
+    # WEZTERM_SHELL_SKIP_ALL            - disables all
+    # WEZTERM_SHELL_SKIP_SEMANTIC_ZONES - disables zones
+    # WEZTERM_SHELL_SKIP_CWD            - disables OSC 7 cwd setting
+    # WEZTERM_SHELL_SKIP_USER_VARS      - disable user vars that capture information about running programs
+# How to test
+   # Set multiclick to select zones in WezTerm, then multiclick to see which areas select
+   # Use MoveForwardZoneOfType/MoveBackwardZoneOfType key bindings
+
+import os
+import subprocess
+
+from xonsh.built_ins import XSH
+
+from . import utils
+
+env = XSH.env or {}
+evalx = XSH.builtins.evalx
+
+_skip_all     = env.get('WEZTERM_SHELL_SKIP_ALL'           , False)
+_skip_cwd     = env.get('WEZTERM_SHELL_SKIP_CWD'           , False)
+_skip_zone    = env.get('WEZTERM_SHELL_SKIP_SEMANTIC_ZONES', False)
+_skip_usr_var = env.get('WEZTERM_SHELL_SKIP_USER_VARS'     , False)
+
+get_bin      = XSH.commands_cache.locate_binary
+get_bin_lazy = XSH.commands_cache.lazy_locate_binary
+def _command(               name, ignore_alias=False):
+    """Find           command        in cache (including aliases)"""
+    return get_bin_lazy(    name, ignore_alias)
+def isCmd(                  name, ignore_alias=False):
+    """Test whether a command exists in cache (including aliases)"""
+    return True if _command(name, ignore_alias) else False
+
+if not _skip_all:
+    def wezterm_write_osc7_cwd(newdir):
+        host = env.get("HOSTNAME", '')
+        utils.write_osc7_cwd(host, newdir)
+        # ↓ don't see the point in a helper function
+        # emits an OSC 7 sequence to inform the terminal of the current working directory.  It prefers to use a helper command provided by WezTerm if WezTerm is installed, but falls back to a simple command otherwise
+        #if isCmd('wezterm') and\
+        #(0 == evalx('wezterm set-working-directory 2>/dev/null').returncode):
+        #    return
+        #else:
+        #    host = env.get("HOSTNAME", '')
+        #    utils.write_osc7_cwd(host, newdir)
+
+    if not _skip_zone:
+        @XSH.builtins.events.on_precommand # Fires just before a command is executed
+        def wezterm_cmd_pre(cmd:str, **_):
+            """Write before starting to print out the output from the command"""
+            utils.SemanticPrompt.write_input_end_output_start()
+            if not _skip_usr_var:
+                utils.set_user_var("WEZTERM_PROG", cmd) # tell WezTerm the full command that is being run
+
+    @XSH.builtins.events.on_postcommand
+    def wezterm_cmd_pos(rtn=0, **_): # Inform WezTerm of command success/failure here
+        opt = {f'{rtn}':None, 'aid':os.getpid()}
+        utils.SemanticPrompt.write_cmd_end(opt)
+
+    if not _skip_cwd:
+        @XSH.builtins.events.on_chdir
+        def onchdir(olddir, newdir, **_):
+            wezterm_write_osc7_cwd(newdir)
+
+    if not _skip_usr_var:
+        @XSH.builtins.events.on_pre_prompt # Fires just before showing the prompt
+        def wezterm_prompt_pre():
+            """Write before starting to print out the output from the command"""
+            promptx = env.get('PROMPT_FIELDS', []) # get Xonsh available prompt fields
+
+            # 1 tell WezTerm that no command is being run
+            utils.set_user_var("WEZTERM_PROG", "")
+
+            # 2 tell WezTerm the username
+            if (user_xon := promptx['user'] if 'user' in promptx else None):
+                user = user_xon
+            else: # fallback to capturing `id -un` ??? likely never needed
+                full_cmd  = ['id','-un']
+                proc  = subprocess.run(full_cmd,capture_output=True)
+                out   = proc.stdout.decode().rstrip('\n')
+                err   = proc.stderr.decode().rstrip('\n')
+                retn  = proc.returncode
+                user  = out
+            utils.set_user_var("WEZTERM_USER", user)
+
+            # 3 tell WezTerm the hostname
+            if   (hostname_wez := env.get('WEZTERM_HOSTNAME')):
+                hostname = hostname_wez
+            elif (hostname_xon := promptx['hostname'] if 'hostname' in promptx else None):
+                hostname = hostname_xon
+            else: # fallback to calling out hostname/ctl ??? likely never needed
+                if   isCmd('hostname'):
+                    full_cmd  = ['hostname']
+                elif isCmd('hostnamectl'):
+                    full_cmd  = ['hostnamectl','hostname']
+                proc  = subprocess.run(full_cmd,capture_output=True)
+                out   = proc.stdout.decode().rstrip('\n')
+                err   = proc.stderr.decode().rstrip('\n')
+                retn  = proc.returncode
+                hostname = out
+                print('set manual lhostname')
+            utils.set_user_var("WEZTERM_HOST", hostname)
+
+            # 4 tell WezTerm whether the pane is running inside tmux
+            if env.get("TMUX", ''):
+                utils.set_user_var("WEZTERM_IN_TMUX", "1")
+            else:
+                utils.set_user_var("WEZTERM_IN_TMUX", "0")
+
+
+    prompt_name = ["PROMPT","RIGHT_PROMPT","BOTTOM_TOOLBAR","MULTILINE_PROMPT"]
+    extend = False if _skip_zone else True
+    opt = {'cl':'m', 'aid':os.getpid()}
+    for prompt in prompt_name:
+        if  XSH.env[prompt]:
+            XSH.env[prompt] = utils.ShellIntegrationPrompt(XSH.env,
+                                prompt_name=prompt, extend=True, ext_opt=opt)


### PR DESCRIPTION
The commits should have enough info, so just a brief summary here:
 - expanded the main utils class to allow for not only the left one, but also the right, bottom, and multiline prompts
 - added the extended semantic prompts codes/functions that are used by WezTerm, grouped them in a separate helper class (only a couple of semi-dupes, but the new functions allow passing options)

All the new functions are opt-in , so iTerm/Kitty should call exactly the same ones as before, though might also move to the new ones (noticed Kitty hardcodes PS1's symbol '.' in `MULTILINE_PROMPT`, while the new functionality allows the same wrapping of the existing env var like for `PROMPT`

I'd like to export `utils.set_user_var` function to allow xonsh users to use an existing functions to communicate with the terminal via user vars, how best to do that?

Tested by selecting/jumping between zones in WezTerm, mostly works fine except for a few of bugs  with WezTerm/Xonsh (commented in the code), you don't have a "Known issues" xontrib-template section in the readme, might be worth adding?

P.S.
`pre-commit install-hooks` failed to install with some poetry `      Preparing metadata (pyproject.toml): finished with status 'error'`, so didn't run it (I guess it sensed that I didn't want to ruin my careful more readable vertical alignment :) 
Could you please run it on your side?

