### PR TITLE
feat: add partial multiline prompt support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,17 @@ pre-commit install-hooks
 
 ## Known issues
 
-- Multiline prompt is not supported due to this [xonsh issue](https://github.com/xonsh/xonsh/issues/5058)
+- (WezTerm) Multiline prompt is partially supported:
+  - every continuation line is semantically marked by default:
+    ```xsh
+    if True:
+    #↓ continuation prompt
+    .....     echo 1
+    #     ↑ input
+    ```
+    so you can select `    echo 1` as a `SemanticZone` with a mouse multiclick, but you can't select both lines as one zone (and would need to map some combo of commands to hack around it)
+  - if you set `$MULTILINE_PROMPT_PRE=''`, `$MULTILINE_PROMPT_POS=''`, then continuation lines won't be marked, you'd be able to select all the lines as one `SemanticZone` (unles the _right_ prompt interferes), but that will also include `..` continuation markers (so you'd either need to disable them in Xonsh or add some extra WezTerm lua parsing hack to trim them)
+    </br> (follow this [WezTerm discussion](https://github.com/wez/wezterm/discussions/3130) for updates)
 - (WezTerm) Semantic _right_ prompt not separated from the next-line _left_ prompt ([issue](https://github.com/wez/wezterm/issues/3115))
 - WezTerm is _not_ recognized in root shells due to [this issue](https://github.com/wez/wezterm/issues/3114)
 

--- a/xontrib_term_integrations/utils.py
+++ b/xontrib_term_integrations/utils.py
@@ -54,12 +54,13 @@ class ShellIntegrationPrompt:
             elif self.prompt_name == "BOTTOM_TOOLBAR":
                 prefix = SemanticPrompt.prompt_start_secondary()
                 suffix = ""  # ... ␤ bugs and adds and extra empty line
-            elif (
-                self.prompt_name == "MULTILINE_PROMPT"
-            ):  # todo: bugs https://github.com/xonsh/xonsh/issues/5058
-                prefix = SemanticPrompt.prompt_start_continue()
-                prefix = ""
-                suffix = ""
+            elif self.prompt_name == "MULTILINE_PROMPT":
+                prefix, suffix = "", ""
+                _pre, _pos = "MULTILINE_PROMPT_PRE", "MULTILINE_PROMPT_POS"
+                if not (_pre_val := envx.get(_pre)) and not _pre_val == "":
+                    envx[_pre] = ansi_esc(SemanticPrompt.prompt_start_continue())
+                if not (_pos_val := envx.get(_pos)) and not _pos_val == "":
+                    envx[_pos] = ansi_esc(SemanticPrompt.prompt_end_input_start())
             else:
                 return prompt
         prefix = (


### PR DESCRIPTION
This is blocked by a PR to Xonsh (linked below) that handles the affixes setting the semantic marks